### PR TITLE
Add Go map key lookup. Until now, the logic to search a value in a map

### DIFF
--- a/internal/include/go_types.h
+++ b/internal/include/go_types.h
@@ -44,6 +44,122 @@ MAP_BUCKET_TYPE(key_type, value_type) { \
     void *overflow; \
 };
 
+struct map_key_find_result {
+    bool found;
+    u32 bucket_index;
+    u32 entry_index;
+    void *key_ptr;
+    go_string_t value_ptr;
+};
+
+MAP_BUCKET_DEFINITION(go_string_t, go_slice_t)
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t)));
+    __uint(max_entries, 1);
+} golang_mapbucket_storage_map SEC(".maps");
+
+#define MAX_MAP_KEY_LENGTH 256
+#define MAX_MAP_BUCKETS 64
+
+// Generic function to search for a key in a Go map
+// Parameters:
+//   map_ptr: pointer to the go map
+//   key_to_find: string to search for
+//   key_length: length of the key to find
+//   buckets_ptr_pos: offset to the buckets pointer from map_ptr
+//   result: pointer to a map_key_find_result structure to store the result
+// Returns:
+//   0 on success, negative value on error
+static __always_inline long find_key_in_go_map(void *map_ptr, const char *key_to_find, u32 key_length, 
+                                        u64 buckets_ptr_pos, struct map_key_find_result *result)
+{
+    long res;
+    if (!map_ptr || !result) {
+        return -1;
+    }
+
+    u64 headers_count = 0;
+    res = bpf_probe_read(&headers_count, sizeof(headers_count), map_ptr);
+    if (res < 0 || headers_count == 0)
+    {
+        return -1;
+    }
+
+    unsigned char log_2_bucket_count;
+    res = bpf_probe_read(&log_2_bucket_count, sizeof(log_2_bucket_count), map_ptr + 9);
+    if (res < 0)
+    {
+        return -1;
+    }
+    
+    u64 bucket_count = 1 << log_2_bucket_count;
+    void *buckets;
+    res = bpf_probe_read(&buckets, sizeof(buckets), (void*)(map_ptr + buckets_ptr_pos));
+    if (res < 0)
+    {
+        return -1;
+    }
+    
+    u32 map_id = 0;
+    MAP_BUCKET_TYPE(go_string_t, go_slice_t) *bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+    if (!bucket)
+    {
+        return -1;
+    }
+
+    // Add a safety cap to iteration
+    for (u64 j = 0; j < MAX_MAP_BUCKETS && j < bucket_count; j++) {
+        void *bucket_addr = buckets + (j * sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t)));
+        
+        // Try both read methods
+        res = bpf_probe_read(bucket, sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t)), buckets + (j * sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t))));
+        if (res < 0)
+        {
+            continue;
+        }
+        
+        for (u64 i = 0; i < 8; i++)
+        {
+            if (bucket->tophash[i] == 0 || bucket->keys[i].len != key_length)
+            {
+                continue;
+            }
+            
+            char current_key[MAX_MAP_KEY_LENGTH];
+            res = bpf_probe_read(current_key, sizeof(current_key), bucket->keys[i].str);
+            if (res < 0) {
+                continue;
+            }
+            
+            if (!bpf_strcasecmp(current_key, key_to_find, key_length))
+            {
+                continue;
+            }
+            void *value_ptr = bucket->values[i].array;
+            
+            struct go_string value_go_str;
+            res = bpf_probe_read(&value_go_str, sizeof(value_go_str), value_ptr);
+            if (res < 0)
+            {
+                return -1;
+            }
+
+            result->found = true;
+            result->bucket_index = j;
+            result->entry_index = i;
+            result->key_ptr = bucket->keys[i].str;
+            result->value_ptr = value_go_str;
+            return 0;
+        }
+    }
+    
+    return -1;
+}
+
 struct slice_array_buff
 {
     unsigned char buff[MAX_SLICE_ARRAY_SIZE];

--- a/internal/include/utils.h
+++ b/internal/include/utils.h
@@ -32,6 +32,24 @@ static __always_inline int bpf_memicmp(const char *s1, const char *s2, s32 size)
     return 0;
 }
 
+// Case-insensitive string comparison, returns true if strings match regardless of case
+static __always_inline bool bpf_strcasecmp(const char *s1, const char *s2, s32 size)
+{
+    #pragma unroll
+    for (int i = 0; i < size; i++)
+    {
+        char c1 = s1[i];
+        char c2 = s2[i];
+        
+        if ((c1 | 0x20) != (c2 | 0x20)) // Bitwise OR with 0x20 converts uppercase to lowercase
+        {
+            return false;
+        }
+    }
+    
+    return true;
+}
+
 static __always_inline void generate_random_bytes(unsigned char *buff, u32 size)
 {
     for (int i = 0; i < (size / 4); i++)

--- a/internal/pkg/instrumentation/bpf/database/sql/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/bpf_arm64_bpfel.go
@@ -81,14 +81,15 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	SqlEvents             *ebpf.MapSpec `ebpf:"sql_events"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	SqlEvents                 *ebpf.MapSpec `ebpf:"sql_events"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -122,14 +123,15 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	SqlEvents             *ebpf.Map `ebpf:"sql_events"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	SqlEvents                 *ebpf.Map `ebpf:"sql_events"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -137,6 +139,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,
 		m.SliceArrayBuffMap,

--- a/internal/pkg/instrumentation/bpf/database/sql/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/database/sql/bpf_x86_bpfel.go
@@ -81,14 +81,15 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	SqlEvents             *ebpf.MapSpec `ebpf:"sql_events"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	SqlEvents                 *ebpf.MapSpec `ebpf:"sql_events"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -122,14 +123,15 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	SqlEvents             *ebpf.Map `ebpf:"sql_events"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	SqlEvents                 *ebpf.Map `ebpf:"sql_events"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -137,6 +139,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,
 		m.SliceArrayBuffMap,

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/bpf_arm64_bpfel.go
@@ -83,17 +83,18 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GoroutineToGoContext   *ebpf.MapSpec `ebpf:"goroutine_to_go_context"`
-	KafkaEvents            *ebpf.MapSpec `ebpf:"kafka_events"`
-	KafkaReaderToConn      *ebpf.MapSpec `ebpf:"kafka_reader_to_conn"`
-	KafkaRequestStorageMap *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GoroutineToGoContext      *ebpf.MapSpec `ebpf:"goroutine_to_go_context"`
+	KafkaEvents               *ebpf.MapSpec `ebpf:"kafka_events"`
+	KafkaReaderToConn         *ebpf.MapSpec `ebpf:"kafka_reader_to_conn"`
+	KafkaRequestStorageMap    *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -133,17 +134,18 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	GoroutineToGoContext   *ebpf.Map `ebpf:"goroutine_to_go_context"`
-	KafkaEvents            *ebpf.Map `ebpf:"kafka_events"`
-	KafkaReaderToConn      *ebpf.Map `ebpf:"kafka_reader_to_conn"`
-	KafkaRequestStorageMap *ebpf.Map `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GoroutineToGoContext      *ebpf.Map `ebpf:"goroutine_to_go_context"`
+	KafkaEvents               *ebpf.Map `ebpf:"kafka_events"`
+	KafkaReaderToConn         *ebpf.Map `ebpf:"kafka_reader_to_conn"`
+	KafkaRequestStorageMap    *ebpf.Map `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -151,6 +153,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GoroutineToGoContext,
 		m.KafkaEvents,
 		m.KafkaReaderToConn,

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/consumer/bpf_x86_bpfel.go
@@ -83,17 +83,18 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GoroutineToGoContext   *ebpf.MapSpec `ebpf:"goroutine_to_go_context"`
-	KafkaEvents            *ebpf.MapSpec `ebpf:"kafka_events"`
-	KafkaReaderToConn      *ebpf.MapSpec `ebpf:"kafka_reader_to_conn"`
-	KafkaRequestStorageMap *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GoroutineToGoContext      *ebpf.MapSpec `ebpf:"goroutine_to_go_context"`
+	KafkaEvents               *ebpf.MapSpec `ebpf:"kafka_events"`
+	KafkaReaderToConn         *ebpf.MapSpec `ebpf:"kafka_reader_to_conn"`
+	KafkaRequestStorageMap    *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -133,17 +134,18 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	GoroutineToGoContext   *ebpf.Map `ebpf:"goroutine_to_go_context"`
-	KafkaEvents            *ebpf.Map `ebpf:"kafka_events"`
-	KafkaReaderToConn      *ebpf.Map `ebpf:"kafka_reader_to_conn"`
-	KafkaRequestStorageMap *ebpf.Map `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GoroutineToGoContext      *ebpf.Map `ebpf:"goroutine_to_go_context"`
+	KafkaEvents               *ebpf.Map `ebpf:"kafka_events"`
+	KafkaReaderToConn         *ebpf.Map `ebpf:"kafka_reader_to_conn"`
+	KafkaRequestStorageMap    *ebpf.Map `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -151,6 +153,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GoroutineToGoContext,
 		m.KafkaEvents,
 		m.KafkaReaderToConn,

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/bpf_arm64_bpfel.go
@@ -84,15 +84,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	KafkaEvents            *ebpf.MapSpec `ebpf:"kafka_events"`
-	KafkaRequestStorageMap *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	KafkaEvents               *ebpf.MapSpec `ebpf:"kafka_events"`
+	KafkaRequestStorageMap    *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -130,15 +131,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	KafkaEvents            *ebpf.Map `ebpf:"kafka_events"`
-	KafkaRequestStorageMap *ebpf.Map `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	KafkaEvents               *ebpf.Map `ebpf:"kafka_events"`
+	KafkaRequestStorageMap    *ebpf.Map `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -146,6 +148,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.KafkaEvents,
 		m.KafkaRequestStorageMap,
 		m.ProbeActiveSamplerMap,

--- a/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/github.com/segmentio/kafka-go/producer/bpf_x86_bpfel.go
@@ -84,15 +84,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	KafkaEvents            *ebpf.MapSpec `ebpf:"kafka_events"`
-	KafkaRequestStorageMap *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	KafkaEvents               *ebpf.MapSpec `ebpf:"kafka_events"`
+	KafkaRequestStorageMap    *ebpf.MapSpec `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -130,15 +131,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	KafkaEvents            *ebpf.Map `ebpf:"kafka_events"`
-	KafkaRequestStorageMap *ebpf.Map `ebpf:"kafka_request_storage_map"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	KafkaEvents               *ebpf.Map `ebpf:"kafka_events"`
+	KafkaRequestStorageMap    *ebpf.Map `ebpf:"kafka_request_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -146,6 +148,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.KafkaEvents,
 		m.KafkaRequestStorageMap,
 		m.ProbeActiveSamplerMap,

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/bpf_arm64_bpfel.go
@@ -76,15 +76,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	ActiveSpansBySpanPtr  *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	NewEvent              *ebpf.MapSpec `ebpf:"new_event"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr      *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	NewEvent                  *ebpf.MapSpec `ebpf:"new_event"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -120,15 +121,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	ActiveSpansBySpanPtr  *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	NewEvent              *ebpf.Map `ebpf:"new_event"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr      *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	NewEvent                  *ebpf.Map `ebpf:"new_event"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -137,6 +139,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.NewEvent,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/auto/sdk/bpf_x86_bpfel.go
@@ -76,15 +76,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	ActiveSpansBySpanPtr  *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	NewEvent              *ebpf.MapSpec `ebpf:"new_event"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr      *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	NewEvent                  *ebpf.MapSpec `ebpf:"new_event"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -120,15 +121,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	ActiveSpansBySpanPtr  *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	NewEvent              *ebpf.Map `ebpf:"new_event"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr      *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	NewEvent                  *ebpf.Map `ebpf:"new_event"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -137,6 +139,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.NewEvent,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf/probe.bpf.c
@@ -119,7 +119,7 @@ struct
     __uint(key_size, sizeof(u32));
     __uint(value_size, sizeof(MAP_BUCKET_TYPE(go_tracer_with_scope_attributes_t, go_tracer_ptr)));
     __uint(max_entries, 1);
-} golang_mapbucket_storage_map SEC(".maps");
+} golang_mapbucket_storage_map_otel SEC(".maps");
 
 struct
 {
@@ -182,7 +182,7 @@ static __always_inline long fill_partial_tracer_id_from_tracers_map(void *tracer
         return -1;
     }
     u32 map_id = 0;
-    MAP_BUCKET_TYPE(go_tracer_id_partial_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+    MAP_BUCKET_TYPE(go_tracer_id_partial_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map_otel, &map_id);
     if (!map_bucket)
     {
         return -1;
@@ -246,7 +246,7 @@ static __always_inline long fill_tracer_id_with_schema_from_tracers_map(void *tr
         return -1;
     }
     u32 map_id = 0;
-    MAP_BUCKET_TYPE(go_tracer_with_schema_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+    MAP_BUCKET_TYPE(go_tracer_with_schema_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map_otel, &map_id);
     if (!map_bucket)
     {
         return -1;
@@ -311,7 +311,7 @@ static __always_inline long fill_tracer_id_with_scope_attributes_from_tracers_ma
         return -1;
     }
     u32 map_id = 0;
-    MAP_BUCKET_TYPE(go_tracer_with_scope_attributes_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
+    MAP_BUCKET_TYPE(go_tracer_with_scope_attributes_t, go_tracer_ptr) *map_bucket = bpf_map_lookup_elem(&golang_mapbucket_storage_map_otel, &map_id);
     if (!map_bucket)
     {
         return -1;

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_arm64_bpfel.go
@@ -109,20 +109,21 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	ActiveSpansBySpanPtr      *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
-	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                    *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
-	OtelSpanStorageMap        *ebpf.MapSpec `ebpf:"otel_span_storage_map"`
-	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	SpanNameByContext         *ebpf.MapSpec `ebpf:"span_name_by_context"`
-	TracerIdByContext         *ebpf.MapSpec `ebpf:"tracer_id_by_context"`
-	TracerIdStorageMap        *ebpf.MapSpec `ebpf:"tracer_id_storage_map"`
-	TracerPtrToIdMap          *ebpf.MapSpec `ebpf:"tracer_ptr_to_id_map"`
-	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr          *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                      *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                        *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc                 *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap     *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GolangMapbucketStorageMapOtel *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map_otel"`
+	OtelSpanStorageMap            *ebpf.MapSpec `ebpf:"otel_span_storage_map"`
+	ProbeActiveSamplerMap         *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap             *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap             *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	SpanNameByContext             *ebpf.MapSpec `ebpf:"span_name_by_context"`
+	TracerIdByContext             *ebpf.MapSpec `ebpf:"tracer_id_by_context"`
+	TracerIdStorageMap            *ebpf.MapSpec `ebpf:"tracer_id_storage_map"`
+	TracerPtrToIdMap              *ebpf.MapSpec `ebpf:"tracer_ptr_to_id_map"`
+	TrackedSpansBySc              *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -172,20 +173,21 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	ActiveSpansBySpanPtr      *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
-	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
-	Events                    *ebpf.Map `ebpf:"events"`
-	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
-	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
-	OtelSpanStorageMap        *ebpf.Map `ebpf:"otel_span_storage_map"`
-	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
-	SpanNameByContext         *ebpf.Map `ebpf:"span_name_by_context"`
-	TracerIdByContext         *ebpf.Map `ebpf:"tracer_id_by_context"`
-	TracerIdStorageMap        *ebpf.Map `ebpf:"tracer_id_storage_map"`
-	TracerPtrToIdMap          *ebpf.Map `ebpf:"tracer_ptr_to_id_map"`
-	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr          *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                      *ebpf.Map `ebpf:"alloc_map"`
+	Events                        *ebpf.Map `ebpf:"events"`
+	GoContextToSc                 *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap     *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GolangMapbucketStorageMapOtel *ebpf.Map `ebpf:"golang_mapbucket_storage_map_otel"`
+	OtelSpanStorageMap            *ebpf.Map `ebpf:"otel_span_storage_map"`
+	ProbeActiveSamplerMap         *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap             *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap             *ebpf.Map `ebpf:"slice_array_buff_map"`
+	SpanNameByContext             *ebpf.Map `ebpf:"span_name_by_context"`
+	TracerIdByContext             *ebpf.Map `ebpf:"tracer_id_by_context"`
+	TracerIdStorageMap            *ebpf.Map `ebpf:"tracer_id_storage_map"`
+	TracerPtrToIdMap              *ebpf.Map `ebpf:"tracer_ptr_to_id_map"`
+	TrackedSpansBySc              *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -195,6 +197,7 @@ func (m *bpfMaps) Close() error {
 		m.Events,
 		m.GoContextToSc,
 		m.GolangMapbucketStorageMap,
+		m.GolangMapbucketStorageMapOtel,
 		m.OtelSpanStorageMap,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/go.opentelemetry.io/otel/traceglobal/bpf_x86_bpfel.go
@@ -109,20 +109,21 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	ActiveSpansBySpanPtr      *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
-	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                    *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
-	OtelSpanStorageMap        *ebpf.MapSpec `ebpf:"otel_span_storage_map"`
-	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	SpanNameByContext         *ebpf.MapSpec `ebpf:"span_name_by_context"`
-	TracerIdByContext         *ebpf.MapSpec `ebpf:"tracer_id_by_context"`
-	TracerIdStorageMap        *ebpf.MapSpec `ebpf:"tracer_id_storage_map"`
-	TracerPtrToIdMap          *ebpf.MapSpec `ebpf:"tracer_ptr_to_id_map"`
-	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr          *ebpf.MapSpec `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                      *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                        *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc                 *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap     *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GolangMapbucketStorageMapOtel *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map_otel"`
+	OtelSpanStorageMap            *ebpf.MapSpec `ebpf:"otel_span_storage_map"`
+	ProbeActiveSamplerMap         *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap             *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap             *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	SpanNameByContext             *ebpf.MapSpec `ebpf:"span_name_by_context"`
+	TracerIdByContext             *ebpf.MapSpec `ebpf:"tracer_id_by_context"`
+	TracerIdStorageMap            *ebpf.MapSpec `ebpf:"tracer_id_storage_map"`
+	TracerPtrToIdMap              *ebpf.MapSpec `ebpf:"tracer_ptr_to_id_map"`
+	TrackedSpansBySc              *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -172,20 +173,21 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	ActiveSpansBySpanPtr      *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
-	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
-	Events                    *ebpf.Map `ebpf:"events"`
-	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
-	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
-	OtelSpanStorageMap        *ebpf.Map `ebpf:"otel_span_storage_map"`
-	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
-	SpanNameByContext         *ebpf.Map `ebpf:"span_name_by_context"`
-	TracerIdByContext         *ebpf.Map `ebpf:"tracer_id_by_context"`
-	TracerIdStorageMap        *ebpf.Map `ebpf:"tracer_id_storage_map"`
-	TracerPtrToIdMap          *ebpf.Map `ebpf:"tracer_ptr_to_id_map"`
-	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	ActiveSpansBySpanPtr          *ebpf.Map `ebpf:"active_spans_by_span_ptr"`
+	AllocMap                      *ebpf.Map `ebpf:"alloc_map"`
+	Events                        *ebpf.Map `ebpf:"events"`
+	GoContextToSc                 *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap     *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GolangMapbucketStorageMapOtel *ebpf.Map `ebpf:"golang_mapbucket_storage_map_otel"`
+	OtelSpanStorageMap            *ebpf.Map `ebpf:"otel_span_storage_map"`
+	ProbeActiveSamplerMap         *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap             *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap             *ebpf.Map `ebpf:"slice_array_buff_map"`
+	SpanNameByContext             *ebpf.Map `ebpf:"span_name_by_context"`
+	TracerIdByContext             *ebpf.Map `ebpf:"tracer_id_by_context"`
+	TracerIdStorageMap            *ebpf.Map `ebpf:"tracer_id_storage_map"`
+	TracerPtrToIdMap              *ebpf.Map `ebpf:"tracer_ptr_to_id_map"`
+	TrackedSpansBySc              *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -195,6 +197,7 @@ func (m *bpfMaps) Close() error {
 		m.Events,
 		m.GoContextToSc,
 		m.GolangMapbucketStorageMap,
+		m.GolangMapbucketStorageMapOtel,
 		m.OtelSpanStorageMap,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/bpf_arm64_bpfel.go
@@ -84,15 +84,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GrpcEvents             *ebpf.MapSpec `ebpf:"grpc_events"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	StreamidToSpanContexts *ebpf.MapSpec `ebpf:"streamid_to_span_contexts"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.MapSpec `ebpf:"grpc_events"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	StreamidToSpanContexts    *ebpf.MapSpec `ebpf:"streamid_to_span_contexts"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -134,15 +135,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	GrpcEvents             *ebpf.Map `ebpf:"grpc_events"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	StreamidToSpanContexts *ebpf.Map `ebpf:"streamid_to_span_contexts"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.Map `ebpf:"grpc_events"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	StreamidToSpanContexts    *ebpf.Map `ebpf:"streamid_to_span_contexts"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -150,6 +152,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GrpcEvents,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/client/bpf_x86_bpfel.go
@@ -84,15 +84,16 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap               *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                 *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc          *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GrpcEvents             *ebpf.MapSpec `ebpf:"grpc_events"`
-	ProbeActiveSamplerMap  *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	StreamidToSpanContexts *ebpf.MapSpec `ebpf:"streamid_to_span_contexts"`
-	TrackedSpansBySc       *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.MapSpec `ebpf:"grpc_events"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	StreamidToSpanContexts    *ebpf.MapSpec `ebpf:"streamid_to_span_contexts"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -134,15 +135,16 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap               *ebpf.Map `ebpf:"alloc_map"`
-	Events                 *ebpf.Map `ebpf:"events"`
-	GoContextToSc          *ebpf.Map `ebpf:"go_context_to_sc"`
-	GrpcEvents             *ebpf.Map `ebpf:"grpc_events"`
-	ProbeActiveSamplerMap  *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap      *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap      *ebpf.Map `ebpf:"slice_array_buff_map"`
-	StreamidToSpanContexts *ebpf.Map `ebpf:"streamid_to_span_contexts"`
-	TrackedSpansBySc       *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.Map `ebpf:"grpc_events"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	StreamidToSpanContexts    *ebpf.Map `ebpf:"streamid_to_span_contexts"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -150,6 +152,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GrpcEvents,
 		m.ProbeActiveSamplerMap,
 		m.SamplersConfigMap,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf_arm64_bpfel.go
@@ -91,16 +91,17 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GrpcEvents            *ebpf.MapSpec `ebpf:"grpc_events"`
-	GrpcStorageMap        *ebpf.MapSpec `ebpf:"grpc_storage_map"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	StreamidToGrpcEvents  *ebpf.MapSpec `ebpf:"streamid_to_grpc_events"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.MapSpec `ebpf:"grpc_events"`
+	GrpcStorageMap            *ebpf.MapSpec `ebpf:"grpc_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	StreamidToGrpcEvents      *ebpf.MapSpec `ebpf:"streamid_to_grpc_events"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -147,16 +148,17 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	GrpcEvents            *ebpf.Map `ebpf:"grpc_events"`
-	GrpcStorageMap        *ebpf.Map `ebpf:"grpc_storage_map"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	StreamidToGrpcEvents  *ebpf.Map `ebpf:"streamid_to_grpc_events"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.Map `ebpf:"grpc_events"`
+	GrpcStorageMap            *ebpf.Map `ebpf:"grpc_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	StreamidToGrpcEvents      *ebpf.Map `ebpf:"streamid_to_grpc_events"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -164,6 +166,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GrpcEvents,
 		m.GrpcStorageMap,
 		m.ProbeActiveSamplerMap,

--- a/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/google.golang.org/grpc/server/bpf_x86_bpfel.go
@@ -91,16 +91,17 @@ type bpfProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type bpfMapSpecs struct {
-	AllocMap              *ebpf.MapSpec `ebpf:"alloc_map"`
-	Events                *ebpf.MapSpec `ebpf:"events"`
-	GoContextToSc         *ebpf.MapSpec `ebpf:"go_context_to_sc"`
-	GrpcEvents            *ebpf.MapSpec `ebpf:"grpc_events"`
-	GrpcStorageMap        *ebpf.MapSpec `ebpf:"grpc_storage_map"`
-	ProbeActiveSamplerMap *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.MapSpec `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
-	StreamidToGrpcEvents  *ebpf.MapSpec `ebpf:"streamid_to_grpc_events"`
-	TrackedSpansBySc      *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.MapSpec `ebpf:"alloc_map"`
+	Events                    *ebpf.MapSpec `ebpf:"events"`
+	GoContextToSc             *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.MapSpec `ebpf:"grpc_events"`
+	GrpcStorageMap            *ebpf.MapSpec `ebpf:"grpc_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.MapSpec `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.MapSpec `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.MapSpec `ebpf:"slice_array_buff_map"`
+	StreamidToGrpcEvents      *ebpf.MapSpec `ebpf:"streamid_to_grpc_events"`
+	TrackedSpansBySc          *ebpf.MapSpec `ebpf:"tracked_spans_by_sc"`
 }
 
 // bpfVariableSpecs contains global variables before they are loaded into the kernel.
@@ -147,16 +148,17 @@ func (o *bpfObjects) Close() error {
 //
 // It can be passed to loadBpfObjects or ebpf.CollectionSpec.LoadAndAssign.
 type bpfMaps struct {
-	AllocMap              *ebpf.Map `ebpf:"alloc_map"`
-	Events                *ebpf.Map `ebpf:"events"`
-	GoContextToSc         *ebpf.Map `ebpf:"go_context_to_sc"`
-	GrpcEvents            *ebpf.Map `ebpf:"grpc_events"`
-	GrpcStorageMap        *ebpf.Map `ebpf:"grpc_storage_map"`
-	ProbeActiveSamplerMap *ebpf.Map `ebpf:"probe_active_sampler_map"`
-	SamplersConfigMap     *ebpf.Map `ebpf:"samplers_config_map"`
-	SliceArrayBuffMap     *ebpf.Map `ebpf:"slice_array_buff_map"`
-	StreamidToGrpcEvents  *ebpf.Map `ebpf:"streamid_to_grpc_events"`
-	TrackedSpansBySc      *ebpf.Map `ebpf:"tracked_spans_by_sc"`
+	AllocMap                  *ebpf.Map `ebpf:"alloc_map"`
+	Events                    *ebpf.Map `ebpf:"events"`
+	GoContextToSc             *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
+	GrpcEvents                *ebpf.Map `ebpf:"grpc_events"`
+	GrpcStorageMap            *ebpf.Map `ebpf:"grpc_storage_map"`
+	ProbeActiveSamplerMap     *ebpf.Map `ebpf:"probe_active_sampler_map"`
+	SamplersConfigMap         *ebpf.Map `ebpf:"samplers_config_map"`
+	SliceArrayBuffMap         *ebpf.Map `ebpf:"slice_array_buff_map"`
+	StreamidToGrpcEvents      *ebpf.Map `ebpf:"streamid_to_grpc_events"`
+	TrackedSpansBySc          *ebpf.Map `ebpf:"tracked_spans_by_sc"`
 }
 
 func (m *bpfMaps) Close() error {
@@ -164,6 +166,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.GrpcEvents,
 		m.GrpcStorageMap,
 		m.ProbeActiveSamplerMap,

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_arm64_bpfel.go
@@ -97,6 +97,7 @@ type bpfMapSpecs struct {
 	AllocMap                   *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                     *ebpf.MapSpec `ebpf:"events"`
 	GoContextToSc              *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.MapSpec `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.MapSpec `ebpf:"http_events"`
 	HttpHeaders                *ebpf.MapSpec `ebpf:"http_headers"`
@@ -160,6 +161,7 @@ type bpfMaps struct {
 	AllocMap                   *ebpf.Map `ebpf:"alloc_map"`
 	Events                     *ebpf.Map `ebpf:"events"`
 	GoContextToSc              *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.Map `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.Map `ebpf:"http_events"`
 	HttpHeaders                *ebpf.Map `ebpf:"http_headers"`
@@ -174,6 +176,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.HttpClientUprobeStorageMap,
 		m.HttpEvents,
 		m.HttpHeaders,

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_no_tp_arm64_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_no_tp_arm64_bpfel.go
@@ -97,6 +97,7 @@ type bpf_no_tpMapSpecs struct {
 	AllocMap                   *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                     *ebpf.MapSpec `ebpf:"events"`
 	GoContextToSc              *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.MapSpec `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.MapSpec `ebpf:"http_events"`
 	HttpHeaders                *ebpf.MapSpec `ebpf:"http_headers"`
@@ -160,6 +161,7 @@ type bpf_no_tpMaps struct {
 	AllocMap                   *ebpf.Map `ebpf:"alloc_map"`
 	Events                     *ebpf.Map `ebpf:"events"`
 	GoContextToSc              *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.Map `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.Map `ebpf:"http_events"`
 	HttpHeaders                *ebpf.Map `ebpf:"http_headers"`
@@ -174,6 +176,7 @@ func (m *bpf_no_tpMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.HttpClientUprobeStorageMap,
 		m.HttpEvents,
 		m.HttpHeaders,

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_no_tp_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_no_tp_x86_bpfel.go
@@ -97,6 +97,7 @@ type bpf_no_tpMapSpecs struct {
 	AllocMap                   *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                     *ebpf.MapSpec `ebpf:"events"`
 	GoContextToSc              *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.MapSpec `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.MapSpec `ebpf:"http_events"`
 	HttpHeaders                *ebpf.MapSpec `ebpf:"http_headers"`
@@ -160,6 +161,7 @@ type bpf_no_tpMaps struct {
 	AllocMap                   *ebpf.Map `ebpf:"alloc_map"`
 	Events                     *ebpf.Map `ebpf:"events"`
 	GoContextToSc              *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.Map `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.Map `ebpf:"http_events"`
 	HttpHeaders                *ebpf.Map `ebpf:"http_headers"`
@@ -174,6 +176,7 @@ func (m *bpf_no_tpMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.HttpClientUprobeStorageMap,
 		m.HttpEvents,
 		m.HttpHeaders,

--- a/internal/pkg/instrumentation/bpf/net/http/client/bpf_x86_bpfel.go
+++ b/internal/pkg/instrumentation/bpf/net/http/client/bpf_x86_bpfel.go
@@ -97,6 +97,7 @@ type bpfMapSpecs struct {
 	AllocMap                   *ebpf.MapSpec `ebpf:"alloc_map"`
 	Events                     *ebpf.MapSpec `ebpf:"events"`
 	GoContextToSc              *ebpf.MapSpec `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.MapSpec `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.MapSpec `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.MapSpec `ebpf:"http_events"`
 	HttpHeaders                *ebpf.MapSpec `ebpf:"http_headers"`
@@ -160,6 +161,7 @@ type bpfMaps struct {
 	AllocMap                   *ebpf.Map `ebpf:"alloc_map"`
 	Events                     *ebpf.Map `ebpf:"events"`
 	GoContextToSc              *ebpf.Map `ebpf:"go_context_to_sc"`
+	GolangMapbucketStorageMap  *ebpf.Map `ebpf:"golang_mapbucket_storage_map"`
 	HttpClientUprobeStorageMap *ebpf.Map `ebpf:"http_client_uprobe_storage_map"`
 	HttpEvents                 *ebpf.Map `ebpf:"http_events"`
 	HttpHeaders                *ebpf.Map `ebpf:"http_headers"`
@@ -174,6 +176,7 @@ func (m *bpfMaps) Close() error {
 		m.AllocMap,
 		m.Events,
 		m.GoContextToSc,
+		m.GolangMapbucketStorageMap,
 		m.HttpClientUprobeStorageMap,
 		m.HttpEvents,
 		m.HttpHeaders,

--- a/internal/pkg/instrumentation/bpf/net/http/server/bpf/probe.bpf.c
+++ b/internal/pkg/instrumentation/bpf/net/http/server/bpf/probe.bpf.c
@@ -40,8 +40,6 @@ struct uprobe_data_t
     u64 resp_ptr;
 };
 
-MAP_BUCKET_DEFINITION(go_string_t, go_slice_t)
-
 struct
 {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -57,14 +55,6 @@ struct
     __type(value, struct span_context);
     __uint(max_entries, MAX_CONCURRENT);
 } http_server_context_headers SEC(".maps");
-
-struct
-{
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(key_size, sizeof(u32));
-    __uint(value_size, sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t)));
-    __uint(max_entries, 1);
-} golang_mapbucket_storage_map SEC(".maps");
 
 struct
 {
@@ -107,85 +97,21 @@ static __always_inline long extract_context_from_req_headers_go_map(void *header
     {
         return res;
     }
-    u64 headers_count = 0;
-    res = bpf_probe_read(&headers_count, sizeof(headers_count), headers_ptr);
+
+    struct map_key_find_result result = {0};
+    res = find_key_in_go_map(headers_ptr, "traceparent", W3C_KEY_LENGTH, buckets_ptr_pos, &result);
+    if (res < 0 || !result.found)
+    {
+        return -1;
+    }
+    char traceparent_header_value[W3C_VAL_LENGTH];
+    res = bpf_probe_read(&traceparent_header_value, sizeof(traceparent_header_value), result.value_ptr.str);
     if (res < 0)
     {
         return res;
     }
-    if (headers_count == 0)
-    {
-        return -1;
-    }
-    unsigned char log_2_bucket_count;
-    res = bpf_probe_read(&log_2_bucket_count, sizeof(log_2_bucket_count), headers_ptr + 9);
-    if (res < 0)
-    {
-        return -1;
-    }
-    u64 bucket_count = 1 << log_2_bucket_count;
-    void *header_buckets;
-    res = bpf_probe_read(&header_buckets, sizeof(header_buckets), (void*)(headers_ptr + buckets_ptr_pos));
-    if (res < 0)
-    {
-        return -1;
-    }
-    u32 map_id = 0;
-    MAP_BUCKET_TYPE(go_string_t, go_slice_t) *map_value = bpf_map_lookup_elem(&golang_mapbucket_storage_map, &map_id);
-    if (!map_value)
-    {
-        return -1;
-    }
-
-    for (u64 j = 0; j < MAX_BUCKETS; j++)
-    {
-        if (j >= bucket_count)
-        {
-            break;
-        }
-        res = bpf_probe_read(map_value, sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t)), header_buckets + (j * sizeof(MAP_BUCKET_TYPE(go_string_t, go_slice_t))));
-        if (res < 0)
-        {
-            continue;
-        }
-        for (u64 i = 0; i < 8; i++)
-        {
-            if (map_value->tophash[i] == 0)
-            {
-                continue;
-            }
-            if (map_value->keys[i].len != W3C_KEY_LENGTH)
-            {
-                continue;
-            }
-            char current_header_key[W3C_KEY_LENGTH];
-            bpf_probe_read(current_header_key, sizeof(current_header_key), map_value->keys[i].str);
-            if (!bpf_memcmp(current_header_key, "traceparent", W3C_KEY_LENGTH) && !bpf_memcmp(current_header_key, "Traceparent", W3C_KEY_LENGTH))
-            {
-                continue;
-            }
-            void *traceparent_header_value_ptr = map_value->values[i].array;
-            struct go_string traceparent_header_value_go_str;
-            res = bpf_probe_read(&traceparent_header_value_go_str, sizeof(traceparent_header_value_go_str), traceparent_header_value_ptr);
-            if (res < 0)
-            {
-                return -1;
-            }
-            if (traceparent_header_value_go_str.len != W3C_VAL_LENGTH)
-            {
-                continue;
-            }
-            char traceparent_header_value[W3C_VAL_LENGTH];
-            res = bpf_probe_read(&traceparent_header_value, sizeof(traceparent_header_value), traceparent_header_value_go_str.str);
-            if (res < 0)
-            {
-                return res;
-            }
-            w3c_string_to_span_context(traceparent_header_value, parent_span_context);
-            return 0;
-        }
-    }
-    return -1;
+    w3c_string_to_span_context(traceparent_header_value, parent_span_context);
+    return 0;
 }
 
 static __always_inline long extract_context_from_req_headers_pre_parsed(void *key, struct span_context *parent_span_context) {


### PR DESCRIPTION
was implemented in the net/http probe. However, this could be reused by other probes.